### PR TITLE
Add java query examples

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,0 +1,15 @@
+# Mac files #
+**/.DS_Store
+
+# IDE files #
+.idea
+**/*.iml
+
+# VS Code files #
+**/.vscode/
+**/.settings/
+**/.project
+**/.classpath
+
+# Compiled files #
+**/target/

--- a/java/queries/README.md
+++ b/java/queries/README.md
@@ -1,0 +1,38 @@
+---
+title: Example Queries using the Java Client
+keywords: graql queries, grakn, java client
+tags: [example]
+sidebar: documentation_sidebar
+permalink: /examples/java/queries
+folder: examples
+symlink: false
+---
+
+## Example Queries using the Java Client
+
+The `src/main/java/ai.grakn.examples/Queries.java`, contains query examples that get executed on the phone_calls knowledge graph.
+
+### Prerequisites
+
+- [Migrating data into the phone_calls Grakn keyspace](https://github.com/graknlabs/examples/tree/master/java/migration)
+- Java 8 (OpenJDK or Oracle Java) with the $JAVA_HOME set accordingly
+- If running on Windows version prior to 10, make sure to have Visual Studio C++ Runtime
+- Basic understading of [GRAKN.AI](http://dev.grakn.ai/docs)
+- Basic knowledge of Java
+
+### Understanding the code
+
+- Read the **[blog post](...)**
+- Study the code/comments in `Queries.java`
+
+## Quick Start
+
+Run:
+
+- [migrate data into the phone_calls Grakn keyspace](https://github.com/graknlabs/examples/tree/master/java/migration)
+- `path-to-grakn-dist-directory/grakn server start` (if Grakn server is not yet running)
+- `git clone git@github.com:graknlabs/examples.git`
+- `cd examples/java/queries`
+- `mvn clean compile assembly:single`
+- `java -cp target/migrate-xml-to-grakn-1.0-SNAPSHOT-jar-with-dependencies.jar ai.grakn.examples.XmlMigration`
+- follow the instructions to run available Graql queries

--- a/java/queries/README.md
+++ b/java/queries/README.md
@@ -34,5 +34,5 @@ Run:
 - `git clone git@github.com:graknlabs/examples.git`
 - `cd examples/java/queries`
 - `mvn clean compile assembly:single`
-- `java -cp target/migrate-xml-to-grakn-1.0-SNAPSHOT-jar-with-dependencies.jar ai.grakn.examples.XmlMigration`
+- `java -cp target/queries-1.0-SNAPSHOT-jar-with-dependencies.jar ai.grakn.examples.Queries`
 - follow the instructions to run available Graql queries

--- a/java/queries/pom.xml
+++ b/java/queries/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>grakn.ai.examples</groupId>
+    <artifactId>queries</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>releases</id>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
+    </repositories>
+
+    <properties>
+        <grakn.version>1.4.1</grakn.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.grakn</groupId>
+            <artifactId>client-java</artifactId>
+            <version>${grakn.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/java/queries/src/main/java/ai/grakn/examples/Queries.java
+++ b/java/queries/src/main/java/ai/grakn/examples/Queries.java
@@ -16,7 +16,7 @@ public class Queries {
             this.question = question;
         }
 
-        String getQuestion() { return question; }
+        String getQuestion() { return this.question; }
 
         abstract void executeQuery(Grakn.Transaction transaction);
     }
@@ -33,14 +33,13 @@ public class Queries {
 
         int qsNumber = -1;
         while (qsNumber < 0 || qsNumber > queryExamples.size()) {
-            System.out.print("choose a number (0 for to answer all questions): ");
+            System.out.print("choose a number (enter 0 for to answer all questions): ");
             try {
                 qsNumber = scanner.nextInt();
             } catch (InputMismatchException e) {
                 scanner.nextLine();
                 System.out.println();
                 System.out.println("Please enter a number!");
-                continue;
             }
 
         }

--- a/java/queries/src/main/java/ai/grakn/examples/Queries.java
+++ b/java/queries/src/main/java/ai/grakn/examples/Queries.java
@@ -1,0 +1,260 @@
+package ai.grakn.examples;
+
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.client.Grakn;
+import ai.grakn.util.SimpleURI;
+
+import java.util.*;
+
+
+public class Queries {
+    abstract static class QueryExample {
+        String question;
+
+        public QueryExample(String question) {
+            this.question = question;
+        }
+
+        String getQuestion() { return question; }
+
+        abstract void executeQuery(Grakn.Transaction transaction);
+    }
+
+    public static void main(String[] args) {
+        List<QueryExample> queryExamples = initialiseQueryExamples();
+
+        Scanner scanner = new Scanner(System.in);
+
+        System.out.print("For which of these questions, on the phone_calls knowledge graph, do you want to execute the query?\n");
+        for (int i = 0; i < queryExamples.size(); i++) {
+            System.out.println(i + 1 + ": " + queryExamples.get(i).getQuestion());
+        }
+
+        int qsNumber = -1;
+        while (qsNumber < 0 || qsNumber > queryExamples.size()) {
+            System.out.print("choose a number (0 for to answer all questions): ");
+            try {
+                qsNumber = scanner.nextInt();
+            } catch (InputMismatchException e) {
+                scanner.nextLine();
+                System.out.println();
+                System.out.println("Please enter a number!");
+                continue;
+            }
+
+        }
+        System.out.println();
+
+        SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+        Keyspace keyspace = Keyspace.of("phone_calls");
+        Grakn grakn = new Grakn(localGrakn);
+        Grakn.Session session = grakn.session(keyspace);
+        Grakn.Transaction transaction = session.transaction(GraknTxType.WRITE);
+
+        if (qsNumber == 0) {
+            queryExamples.forEach(queryExample -> {
+                queryExample.executeQuery(transaction);
+            });
+        } else {
+            queryExamples.get(qsNumber - 1).executeQuery(transaction);
+        }
+
+        transaction.close();
+        session.close();
+    }
+
+    // GRAQL QUERY EXAMPLES
+    static List<QueryExample> initialiseQueryExamples() {
+        List<QueryExample> queryExamples = new ArrayList<>();
+
+        queryExamples.add(new QueryExample("Since September 14th, which customers called the person with phone number +86 921 547 9004?") {
+            @Override
+            void executeQuery(Grakn.Transaction tx) {
+                printToLog("Question: ", this.question);
+
+                List<String> queryAsList = Arrays.asList(
+                        "match",
+                        "  $customer isa person has phone-number $phone-number;",
+                        "  $company isa company has name \"Telecom\";",
+                        "  (customer: $customer, provider: $company) isa contract;",
+                        "  $target isa person has phone-number \"+86 921 547 9004\";",
+                        "  (caller: $customer, callee: $target) isa call has started-at $started-at;",
+                        "  $min-date == 2018-09-14T17:18:49; $started-at > $min-date;",
+                        "get $phone-number;"
+                );
+
+                printToLog("Query:", String.join("\n", queryAsList));
+                String query = String.join("", queryAsList);
+
+                List<String> result = new ArrayList<>();
+                tx.graql().parse(query).execute().forEach(answer -> {
+                    result.add(answer.asConceptMap().get("phone-number").asAttribute().value().toString());
+                });
+                printToLog("Result: ", String.join(", ", result));
+            }
+        });
+
+        queryExamples.add(new QueryExample("Who are the people who have received a call from a London customer aged over 50 who has previously called someone aged under 20?") {
+            @Override
+            void executeQuery(Grakn.Transaction tx) {
+                printToLog("Question: ", this.question);
+
+                List<String> queryAsList = Arrays.asList(
+                        "match ",
+                        "  $suspect isa person has city \"London\", has age > 50;",
+                        "  $company isa company has name \"Telecom\";",
+                        "  (customer: $suspect, provider: $company) isa contract;",
+                        "  $pattern-callee isa person has age < 20;",
+                        "  (caller: $suspect, callee: $pattern-callee) isa call has started-at $pattern-call-date;",
+                        "  $target isa person has phone-number $phone-number, has is-customer false;",
+                        "  (caller: $suspect, callee: $target) isa call has started-at $target-call-date;",
+                        "  $target-call-date > $pattern-call-date;",
+                        "get $phone-number;"
+                );
+
+                printToLog("Query:", String.join("\n", queryAsList));
+                String query = String.join("", queryAsList);
+
+                List<String> result = new ArrayList<>();
+                tx.graql().parse(query).execute().forEach(answer -> {
+                    result.add(answer.asConceptMap().get("phone-number").asAttribute().value().toString());
+                });
+                printToLog("Result: ", String.join(", ", result));
+            }
+        });
+
+        queryExamples.add(new QueryExample("Who are the common contacts of customers with phone numbers +7 171 898 0853 and +370 351 224 5176?") {
+            @Override
+            void executeQuery(Grakn.Transaction tx) {
+                printToLog("Question: ", this.question);
+
+                List<String> queryAsList = Arrays.asList(
+                        "match ",
+                        "  $common-contact isa person has phone-number $phone-number;",
+                        "  $customer-a isa person has phone-number \"+7 171 898 0853\";",
+                        "  $customer-b isa person has phone-number \"+370 351 224 5176\";",
+                        "  (caller: $customer-a, callee: $common-contact) isa call;",
+                        "  (caller: $customer-b, callee: $common-contact) isa call;",
+                        "get $phone-number;"
+                );
+
+                printToLog("Query:", String.join("\n", queryAsList));
+                String query = String.join("", queryAsList);
+
+                List<String> result = new ArrayList<>();
+                tx.graql().parse(query).execute().forEach(answer -> {
+                    result.add(answer.asConceptMap().get("phone-number").asAttribute().value().toString());
+                });
+                printToLog("Result: ", String.join(", ", result));
+            }
+        });
+
+        queryExamples.add(new QueryExample("Who are the customers who 1) have all called each other and 2) have all called person with phone number +48 894 777 5173 at least once?") {
+            @Override
+            void executeQuery(Grakn.Transaction tx) {
+                printToLog("Question: ", this.question);
+
+                List<String> queryAsList = Arrays.asList(
+                        "match ",
+                        "  $target isa person has phone-number \"+48 894 777 5173\";",
+                        "  $company isa company has name \"Telecom\";",
+                        "  $customer-a isa person has phone-number $phone-number-a;",
+                        "  (customer: $customer-a, provider: $company) isa contract;",
+                        "  (caller: $customer-a, callee: $target) isa call;",
+                        "  $customer-b isa person has phone-number $phone-number-b;",
+                        "  (customer: $customer-b, provider: $company) isa contract;",
+                        "  (caller: $customer-b, callee: $target) isa call;",
+                        "  (caller: $customer-a, callee: $customer-b) isa call;",
+                        "get $phone-number-a, $phone-number-b;"
+                );
+
+                printToLog("Query:", String.join("\n", queryAsList));
+                String query = String.join("", queryAsList);
+
+                Set<String> result = new HashSet<>();
+                tx.graql().parse(query).execute().forEach(answer -> {
+                    System.out.println(answer);
+                    result.add(answer.asConceptMap().get("phone-number-a").asAttribute().value().toString());
+                    result.add(answer.asConceptMap().get("phone-number-b").asAttribute().value().toString());
+                });
+                printToLog("Result: ", String.join(", ", result));
+            }
+        });
+
+        queryExamples.add(new QueryExample("How does the average call duration among customers aged under 20 compare those aged over 40?") {
+            @Override
+            void executeQuery(Grakn.Transaction tx) {
+                printToLog("Question: ", this.question);
+
+                List<String> firstQueryAsList = Arrays.asList(
+                        "match",
+                        "  $customer isa person has age < 20;",
+                        "  $company isa company has name \"Telecom\";",
+                        "  (customer: $customer, provider: $company) isa contract;",
+                        "  (caller: $customer, callee: $anyone) isa call has duration $duration;",
+                        "aggregate mean $duration;"
+                );
+
+                printToLog("First Query:", String.join("\n", firstQueryAsList));
+                String firstQuery = String.join("", firstQueryAsList);
+
+                float fisrtResult = tx.graql().parse(firstQuery).execute().get(0).asValue().number().floatValue();
+                String result = "Customers aged under 20 have made calls with average duration of " + fisrtResult + " seconds.\n";
+
+                List<String> secondQueryAsList = Arrays.asList(
+                        "match",
+                        "  $customer isa person has age > 40;",
+                        "  $company isa company has name \"Telecom\";",
+                        "  (customer: $customer, provider: $company) isa contract;",
+                        "  (caller: $customer, callee: $anyone) isa call has duration $duration;",
+                        "aggregate mean $duration;"
+                );
+
+                printToLog("Second Query:", String.join("\n", secondQueryAsList));
+                String secondQuery = String.join("", secondQueryAsList);
+
+                float secondResult = tx.graql().parse(secondQuery).execute().get(0).asValue().number().floatValue();
+                result += "Customers aged over 40 have made calls with average duration of " + secondResult + " seconds.\n";
+
+                printToLog("Result: ", String.join(", ", result));
+
+            }
+        });
+
+        // TO ADD A NEW QUERY EXAMPLE:
+//        queryExamples.add(new QueryExample("question goes here") {
+//            @Override
+//            void executeQuery(Grakn.Transaction tx) {
+//                printToLog("Question: ", this.question);
+//
+//                // queries are written as a list for better readability
+//                List<String> queryAsList = Arrays.asList(
+//                        "each line;",
+//                        "  as an element;",
+//                        "ends with semicolon"
+//                );
+//
+//                // join the query list elements with a new line before printing
+//                printToLog("Query:", String.join("\n", queryAsList));
+//                // join the query list elements to obtain the quer as a string to be executed
+//                String query = String.join("", queryAsList);
+//
+//                List<String> result = new ArrayList<>();
+//                tx.graql().parse(query).execute().forEach(answer -> {
+//                    // retrieve answers
+//                });
+//                printToLog("Result: ", String.join(", ", result));
+//            }
+//        });
+
+        return queryExamples;
+    }
+
+    static void printToLog(String title, String content) {
+        System.out.println(title);
+        System.out.println();
+        System.out.println(content);
+        System.out.println();
+    }
+}

--- a/java/queries/src/main/resources/logback.xml
+++ b/java/queries/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ GRAKN.AI - THE KNOWLEDGE GRAPH
+  ~ Copyright (C) 2018 Grakn Labs Ltd
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<configuration debug="false">
+    <root level="INFO"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ai.grakn.examples" level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+</configuration>


### PR DESCRIPTION
## What's this PR for? closes #28 
To add examples for running various queries using the Java client.

'java/queries' contains a file called `Queries.java`. This file when run, allows the user to select a question they want to get the answer to.

The code is documented to provide instructions for adding a new query exa,[;e.

There is a Readme, that describes how `Queries.java` is meant to be used/studied.

## What's missing?
2 `compute` example queries on the `phone_calls` knowledge graph