### PR TITLE
Updated dependencies to sync with Grakn Core 1.5.2

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,33 +22,33 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d2be22150c8ca386162e0c49d3f82785a11e8d98", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "05ad27318aa97bd4ba2182e48b37ded068e95e2a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.5.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.5.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        tag = "1.5.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        tag = "1.5.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_client_python():
     git_repository(
         name = "graknlabs_client_python",
         remote = "https://github.com/graknlabs/client-python",
-        tag = "1.5.1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
+        tag = "1.5.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
     )
 
 def graknlabs_client_nodejs():
     git_repository(
         name = "graknlabs_client_nodejs",
         remote = "https://github.com/graknlabs/client-nodejs",
-        tag = "1.5.1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
+        tag = "1.5.3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
     )

--- a/phone_calls/java/README.md
+++ b/phone_calls/java/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.0](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/phone_calls/java/README.md
+++ b/phone_calls/java/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [the latest Grakn](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/phone_calls/nodejs/README.md
+++ b/phone_calls/nodejs/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.0](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/phone_calls/nodejs/README.md
+++ b/phone_calls/nodejs/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [the latest Grakn](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/phone_calls/nodejs/package.json
+++ b/phone_calls/nodejs/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Grakn Labs (community@grakn.ai)",
     "dependencies": {
-        "grakn-client": "1.5.1",
+        "grakn-client": "1.5.3",
         "jasmine": "^2.9.0",
         "jasmine-reporters": "^2.3.2",
         "papaparse": "^4.6.3",

--- a/phone_calls/python/README.md
+++ b/phone_calls/python/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.0](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/phone_calls/python/README.md
+++ b/phone_calls/python/README.md
@@ -5,7 +5,7 @@ The Phone Calls Java example showcases:
 2. writing and performing expressive Graql queries to gain insights over the dataset
 
 ### Quickstart
-1. Install [Grakn 1.5.2](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
+1. Install [the latest Grakn](http://dev.grakn.ai/docs/running-grakn/install-and-run#download-and-install-grakn)
 2. Clone this repository
 3. Via terminal while inside the Grakn distribution, run: `./grakn console -k phone_calls -f path-to-the-cloned-repo/schemas/phone-calls-schema.gql`
 4. Start the [Grakn Sever](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server).

--- a/tube_network/README.md
+++ b/tube_network/README.md
@@ -8,7 +8,7 @@ See the _Quickstart_ for how to get going immediately, or read on for more info.
 
 ## Prerequisites
 
-- Grakn >= 1.5.0 Learn more about [installing and running Grakn](http://dev.grakn.ai/docs/running-grakn/install-and-run).
+- Grakn >= 1.5.2 Learn more about [installing and running Grakn](http://dev.grakn.ai/docs/running-grakn/install-and-run).
 - Python >= 3.6
 
 ## Quickstart


### PR DESCRIPTION
## What is the goal of this PR?

We have updated the dependencies to `grakn-core` 1.5.2, `client-java` 1.5.2, `client-python` 1.5.2, and `client-nodejs` 1.5.3.