### PR TITLE
phone_calls: replace is-customer with negation

### DIFF
--- a/phone_calls/java/CSVMigration.java
+++ b/phone_calls/java/CSVMigration.java
@@ -93,7 +93,7 @@ public class CSVMigration {
                 // insert person
                 String graqlInsertQuery = "insert $person isa person, has phone-number " + person.at("phone_number");
 
-                if (!person.at("first_name").isNull()) {
+                if (! person.at("first_name").isNull()) {
                     graqlInsertQuery += ", has first-name " + person.at("first_name");
                     graqlInsertQuery += ", has last-name " + person.at("last_name");
                     graqlInsertQuery += ", has city " + person.at("city");

--- a/phone_calls/java/CSVMigration.java
+++ b/phone_calls/java/CSVMigration.java
@@ -93,12 +93,7 @@ public class CSVMigration {
                 // insert person
                 String graqlInsertQuery = "insert $person isa person, has phone-number " + person.at("phone_number");
 
-                if (person.at("first_name").isNull()) {
-                    // person is not a customer
-                    graqlInsertQuery += ", has is-customer false";
-                } else {
-                    // person is a customer
-                    graqlInsertQuery += ", has is-customer true";
+                if (!person.at("first_name").isNull()) {
                     graqlInsertQuery += ", has first-name " + person.at("first_name");
                     graqlInsertQuery += ", has last-name " + person.at("last_name");
                     graqlInsertQuery += ", has city " + person.at("city");

--- a/phone_calls/java/JSONMigration.java
+++ b/phone_calls/java/JSONMigration.java
@@ -83,12 +83,7 @@ public class JSONMigration {
                 // insert person
                 String graqlInsertQuery = "insert $person isa person, has phone-number " + person.at("phone_number");
 
-                if (! person.has("first_name")) {
-                    // person is not a customer
-                    graqlInsertQuery += ", has is-customer false";
-                } else {
-                    // person is a customer
-                    graqlInsertQuery += ", has is-customer true";
+                if (person.has("first_name")) {
                     graqlInsertQuery += ", has first-name " + person.at("first_name");
                     graqlInsertQuery += ", has last-name " + person.at("last_name");
                     graqlInsertQuery += ", has city " + person.at("city");

--- a/phone_calls/java/Queries.java
+++ b/phone_calls/java/Queries.java
@@ -111,7 +111,8 @@ public class Queries {
                         "  (customer: $suspect, provider: $company) isa contract;",
                         "  $pattern-callee isa person, has age < 20;",
                         "  (caller: $suspect, callee: $pattern-callee) isa call, has started-at $pattern-call-date;",
-                        "  $target isa person, has phone-number $phone-number, has is-customer false;",
+                        "  $target isa person, has phone-number $phone-number;",
+                        "  not { (customer: $target, provider: $company) isa contract; };",
                         "  (caller: $suspect, callee: $target) isa call, has started-at $target-call-date;",
                         "  $target-call-date > $pattern-call-date;",
                         "get $phone-number;"

--- a/phone_calls/java/XMLMigration.java
+++ b/phone_calls/java/XMLMigration.java
@@ -87,12 +87,7 @@ public class XMLMigration {
                 // insert person
                 String graqlInsertQuery = "insert $person isa person, has phone-number " + person.at("phone_number");
 
-                if (! person.has("first_name")) {
-                    // person is not a customer
-                    graqlInsertQuery += ", has is-customer false";
-                } else {
-                    // person is a customer
-                    graqlInsertQuery += ", has is-customer true";
+                if (person.has("first_name")) {
                     graqlInsertQuery += ", has first-name " + person.at("first_name");
                     graqlInsertQuery += ", has last-name " + person.at("last_name");
                     graqlInsertQuery += ", has city " + person.at("city");

--- a/phone_calls/nodejs/migrateCsv.js
+++ b/phone_calls/nodejs/migrateCsv.js
@@ -74,13 +74,8 @@ function personTemplate(person) {
 	const { first_name, last_name, phone_number, city, age } = person;
 	// insert person
 	let graqlInsertQuery = `insert $person isa person, has phone-number "${phone_number}"`;
-	const isNotCustomer = first_name === "";
-	if (isNotCustomer) {
-		// person is not a customer
-		graqlInsertQuery += ", has is-customer false";
-	} else {
-		// person is a customer
-		graqlInsertQuery += `, has is-customer true`;
+
+	if (first_name !== "") {
 		graqlInsertQuery += `, has first-name "${first_name}"`;
 		graqlInsertQuery += `, has last-name "${last_name}"`;
 		graqlInsertQuery += `, has city "${city}"`;

--- a/phone_calls/nodejs/migrateJson.js
+++ b/phone_calls/nodejs/migrateJson.js
@@ -80,13 +80,8 @@ function personTemplate(person) {
 	const { first_name, last_name, phone_number, city, age } = person;
 	// insert person
 	let graqlInsertQuery = `insert $person isa person, has phone-number "${phone_number}"`;
-	const isNotCustomer = typeof first_name === "undefined";
-	if (isNotCustomer) {
-		// person is not a customer
-		graqlInsertQuery += ", has is-customer false";
-	} else {
-		// person is a customer
-		graqlInsertQuery += `, has is-customer true`;
+
+	if (typeof first_name !== "undefined") {
 		graqlInsertQuery += `, has first-name "${first_name}"`;
 		graqlInsertQuery += `, has last-name "${last_name}"`;
 		graqlInsertQuery += `, has city "${city}"`;

--- a/phone_calls/nodejs/migrateXml.js
+++ b/phone_calls/nodejs/migrateXml.js
@@ -88,13 +88,8 @@ function personTemplate(person) {
 	const { first_name, last_name, phone_number, city, age } = person;
 	// insert person
 	let graqlInsertQuery = `insert $person isa person, has phone-number "${phone_number}"`;
-	const isNotCustomer = typeof first_name === "undefined";
-	if (isNotCustomer) {
-		// person is not a customer
-		graqlInsertQuery += ", has is-customer false";
-	} else {
-		// person is a customer
-		graqlInsertQuery += `, has is-customer true`;
+
+	if (typeof first_name !== "undefined") {
 		graqlInsertQuery += `, has first-name "${first_name}"`;
 		graqlInsertQuery += `, has last-name "${last_name}"`;
 		graqlInsertQuery += `, has city "${city}"`;

--- a/phone_calls/nodejs/package.json
+++ b/phone_calls/nodejs/package.json
@@ -25,7 +25,7 @@
         "migrateCsv": "node -e 'require(\"./migrateCsv\").init(\"../../datasets/phone-calls/\")'",
         "migrateJson": "node -e 'require(\"./migrateJson\").init(\"../../datasets/phone-calls/\")'",
         "migrateXml": "node -e 'require(\"./migrateXml\").init(\"../../datasets/phone-calls/\")'",
-        "queries": "node queries.js"
+        "queries": "node -e 'require(\"./queries\").init()'"
     },
     "version": "1.0.0"
 }

--- a/phone_calls/nodejs/queries.js
+++ b/phone_calls/nodejs/queries.js
@@ -1,4 +1,4 @@
-const Grakn = require("grakn-client");
+const GraknClient = require("grakn-client");
 const readline = require("readline");
 
 // to add a new query implementation:
@@ -120,7 +120,8 @@ async function executeQuery2(question, transaction) {
 		"  (customer: $suspect, provider: $company) isa contract;",
 		"  $pattern-callee isa person, has age < 20;",
 		"  (caller: $suspect, callee: $pattern-callee) isa call, has started-at $pattern-call-date;",
-		"  $target isa person, has phone-number $phone-number, has is-customer false;",
+		"  $target isa person, has phone-number $phone-number;",
+        "  not { (customer: $target, provider: $company) isa contract; };",
 		"  (caller: $suspect, callee: $target) isa call, has started-at $target-call-date;",
 		"  $target-call-date > $pattern-call-date;",
 		"get $phone-number;"
@@ -283,9 +284,9 @@ async function executeQuery7(question, transaction) {
 // execute all queries for all questions
 async function executeAllQueries(transaction) {
 	for (queryExample of queryExamples) {
-		qustion = queryExample["question"];
+		question = queryExample["question"];
 		queryFunction = queryExample["queryFunction"];
-		await queryFunction(qustion, transaction);
+		await queryFunction(question, transaction);
 		log("\n - - -  - - -  - - -  - - - \n");
 	}
 }
@@ -312,7 +313,7 @@ async function executeQueries() {
 /**
  * a recursive function that terminates after receiving a valid input
  * otherwise keeps asking
- * @param {pnkect} rl the readline insterface to receive input via console
+ * @param {object} rl the readline insterface to receive input via console
  * exists on completion
  */
 function executeBasedOnSelection(rl) {
@@ -335,9 +336,9 @@ function executeBasedOnSelection(rl) {
  * @param {integer} qsNumber the (question) number selected by the user
  */
 async function processSelection(qsNumber) {
-	const grakn = new Grakn("localhost:48555"); // 1
-	const session = await grakn.session((keyspace = "phone_calls")); // 2
-	const transaction = await session.transaction(Grakn.txType.WRITE); // 3
+	const client = new GraknClient("localhost:48555"); // 1
+	const session = await client.session((keyspace = "phone_calls")); // 2
+	const transaction = await session.transaction().write(); // 3
 
 	if (qsNumber == 0) {
 		await executeAllQueries(transaction); // 4
@@ -350,6 +351,7 @@ async function processSelection(qsNumber) {
 	await session.close(); // 5
 	client.close(); // 6
 }
+
 
 module.exports.queryExamples = queryExamples;
 module.exports.init = executeQueries;

--- a/phone_calls/python/migrate_csv.py
+++ b/phone_calls/python/migrate_csv.py
@@ -60,12 +60,7 @@ def person_template(person):
     # insert person
     graql_insert_query = 'insert $person isa person, has phone-number "' + \
         person["phone_number"] + '"'
-    if person["first_name"] == "":
-        # person is not a customer
-        graql_insert_query += ", has is-customer false"
-    else:
-        # person is a customer
-        graql_insert_query += ", has is-customer true"
+    if person["first_name"] != "":
         graql_insert_query += ', has first-name "' + person["first_name"] + '"'
         graql_insert_query += ', has last-name "' + person["last_name"] + '"'
         graql_insert_query += ', has city "' + person["city"] + '"'

--- a/phone_calls/python/migrate_json.py
+++ b/phone_calls/python/migrate_json.py
@@ -61,15 +61,10 @@ def person_template(person):
     graql_insert_query = 'insert $person isa person, has phone-number "' + \
         person["phone_number"] + '"'
     if "first_name" in person:
-        # person is a customer
-        graql_insert_query += ", has is-customer true"
         graql_insert_query += ', has first-name "' + person["first_name"] + '"'
         graql_insert_query += ', has last-name "' + person["last_name"] + '"'
         graql_insert_query += ', has city "' + person["city"] + '"'
         graql_insert_query += ", has age " + str(person["age"])
-    else:
-        # person is not a customer
-        graql_insert_query += ", has is-customer false"
     graql_insert_query += ";"
     return graql_insert_query
 

--- a/phone_calls/python/migrate_xml.py
+++ b/phone_calls/python/migrate_xml.py
@@ -61,15 +61,10 @@ def person_template(person):
     graql_insert_query = 'insert $person isa person, has phone-number "' + \
         person["phone_number"] + '"'
     if "first_name" in person:
-        # person is a customer
-        graql_insert_query += ", has is-customer true"
         graql_insert_query += ', has first-name "' + person["first_name"] + '"'
         graql_insert_query += ', has last-name "' + person["last_name"] + '"'
         graql_insert_query += ', has city "' + person["city"] + '"'
         graql_insert_query += ", has age " + str(person["age"])
-    else:
-        # person is not a customer
-        graql_insert_query += ", has is-customer false"
     graql_insert_query += ";"
     return graql_insert_query
 

--- a/phone_calls/python/queries.py
+++ b/phone_calls/python/queries.py
@@ -87,7 +87,8 @@ def execute_query_2(question, transaction):
         '  (customer: $suspect, provider: $company) isa contract;',
         '  $pattern-callee isa person, has age < 20;',
         '  (caller: $suspect, callee: $pattern-callee) isa call, has started-at $pattern-call-date;',
-        '  $target isa person, has phone-number $phone-number, has is-customer false;',
+        '  $target isa person, has phone-number $phone-number;',
+        '  not { (customer: $target, provider: $company) isa contract; };',
         '  (caller: $suspect, callee: $target) isa call, has started-at $target-call-date;',
         '  $target-call-date > $pattern-call-date;',
         'get $phone-number;'
@@ -294,6 +295,6 @@ if __name__ == "__main__":
                 if qs_number == 0:
                     execute_query_all(transaction)
                 else:
-                    qustion = query_examples[qs_number - 1]["question"]
+                    question = query_examples[qs_number - 1]["question"]
                     query_function = query_examples[qs_number - 1]["query_function"]
-                    query_function(qustion, transaction)
+                    query_function(question, transaction)

--- a/schemas/phone-calls-schema.gql
+++ b/schemas/phone-calls-schema.gql
@@ -16,8 +16,6 @@ define
       datatype string;
     age sub attribute,
       datatype long;
-    is-customer sub attribute,
-      datatype boolean;
 
     contract sub relation,
         relates provider,
@@ -41,5 +39,4 @@ define
         has last-name,
         has phone-number,
         has city,
-        has age,
-        has is-customer;
+        has age;


### PR DESCRIPTION
## What is the goal of this PR?
Prior to introducing negation in Graql, we had an attribute called `is_customer` assigned to `person` in the `phone_calls` schema. This was done as a workaround in the absence of negation. Now the `phone_calls` example makes use of negation to query for people who are _not_ customers, within the `phone_calls` knowledge graph.

## What are the changes implemented in this PR?
- closes #59 
- removes the definition of `is_customer` attribute and its assignment to `person` from the `phone-calls-schema.gql`
- updates the migration scripts to not assign a value for the `is-customer` attribute when construction the insert queries.
- updates the single one query that used the `is-customer` attribute to use a negation instead.
- resolves issues with the `queries.js` that were and still are not covered by `test.js`. there is an open issue (https://github.com/graknlabs/examples/issues/60) to attend to this.
