### PR TITLE
Increase the timeout of a tube network example test

### DIFF
--- a/tube_network/BUILD
+++ b/tube_network/BUILD
@@ -45,6 +45,7 @@ py_library(
 py_test(
     name = "test",
     main = "test.py",
+    size = "large",
     srcs = [
         "test.py",
         ":migration",


### PR DESCRIPTION
## What is the goal of this PR?

We have seen a test for the tube network example failing non-deterministically, which we believe is due to the test timing out, which is now fixed.

## What are the changes implemented in this PR?

We have increased the timeout for the test.