### PR TITLE
Increases test coverage for phone_calls and tube_network

### DIFF
--- a/phone_calls/java/PhoneCallsTest.java
+++ b/phone_calls/java/PhoneCallsTest.java
@@ -64,9 +64,11 @@ public class PhoneCallsTest {
 
     @Test
     public void testQueries() throws FileNotFoundException {
-        CSVMigration.main(new String[]{ keyspaceName });
-
         List<Queries.QueryExample> queryExamples = Queries.getTestSubjects();
+
+        Queries.processSelection(0, queryExamples);
+
+        CSVMigration.main(new String[]{ keyspaceName });
 
         GraknClient.Transaction transaction = session.transaction().read();
 

--- a/phone_calls/java/PhoneCallsTest.java
+++ b/phone_calls/java/PhoneCallsTest.java
@@ -66,7 +66,7 @@ public class PhoneCallsTest {
     public void testQueries() throws FileNotFoundException {
         List<Queries.QueryExample> queryExamples = Queries.getTestSubjects();
 
-        Queries.processSelection(0, queryExamples);
+        Queries.processSelection(0, queryExamples, keyspaceName);
 
         CSVMigration.main(new String[]{ keyspaceName });
 

--- a/phone_calls/java/Queries.java
+++ b/phone_calls/java/Queries.java
@@ -45,7 +45,10 @@ public class Queries {
 
         }
         System.out.println();
+        processSelection(qsNumber, queryExamples);
+    }
 
+    static void processSelection(Integer qsNumber, List<QueryExample>  queryExamples) {
         GraknClient client = new GraknClient("localhost:48555");
         GraknClient.Session session = client.session("phone_calls");
         GraknClient.Transaction transaction = session.transaction().read();

--- a/phone_calls/java/Queries.java
+++ b/phone_calls/java/Queries.java
@@ -45,12 +45,12 @@ public class Queries {
 
         }
         System.out.println();
-        processSelection(qsNumber, queryExamples);
+        processSelection(qsNumber, queryExamples, "phone_calls");
     }
 
-    static void processSelection(Integer qsNumber, List<QueryExample>  queryExamples) {
+    static void processSelection(Integer qsNumber, List<QueryExample>  queryExamples, String keyspaceName) {
         GraknClient client = new GraknClient("localhost:48555");
-        GraknClient.Session session = client.session("phone_calls");
+        GraknClient.Session session = client.session(keyspaceName);
         GraknClient.Transaction transaction = session.transaction().read();
 
         if (qsNumber == 0) {

--- a/phone_calls/nodejs/queries.js
+++ b/phone_calls/nodejs/queries.js
@@ -331,14 +331,15 @@ function executeBasedOnSelection(rl) {
  * 2. create a session of the instance, connecting to the keyspace phone_calls
  * 3. create a transaction, off the session
  * 4. call the function corresponding to the selected question
- * 5. close the session
- * 6. closes the client
+ * 5. close the transaction
+ * 6. close the session
+ * 7. closes the client
  * @param {integer} qsNumber the (question) number selected by the user
  */
 async function processSelection(qsNumber) {
 	const client = new GraknClient("localhost:48555"); // 1
 	const session = await client.session((keyspace = "phone_calls")); // 2
-	const transaction = await session.transaction().write(); // 3
+	const transaction = await session.transaction().read(); // 3
 
 	if (qsNumber == 0) {
 		await executeAllQueries(transaction); // 4
@@ -347,11 +348,11 @@ async function processSelection(qsNumber) {
 		const queryFunction = queryExamples[qsNumber - 1]["queryFunction"];
 		await queryFunction(question, transaction); // 4
 	}
-
-	await session.close(); // 5
-	client.close(); // 6
+	await transaction.close(); // 5
+	await session.close(); // 6
+	client.close(); // 7
 }
 
-
+module.exports.processSelection = processSelection;
 module.exports.queryExamples = queryExamples;
 module.exports.init = executeQueries;

--- a/phone_calls/nodejs/queries.js
+++ b/phone_calls/nodejs/queries.js
@@ -320,7 +320,7 @@ function executeBasedOnSelection(rl) {
 	const question = "choose a number (0 for to answer all questions): ";
 	rl.question(question, async function (answer, rl) {
 		if (answer >= 0 && answer < queryExamples.length + 1) {
-			await processSelection(answer);
+			await processSelection(answer, "phone_calls");
 			process.exit(0);
 		}
 		executeBasedOnSelection(rl);
@@ -336,9 +336,9 @@ function executeBasedOnSelection(rl) {
  * 7. closes the client
  * @param {integer} qsNumber the (question) number selected by the user
  */
-async function processSelection(qsNumber) {
+async function processSelection(qsNumber, keyspaceName) {
 	const client = new GraknClient("localhost:48555"); // 1
-	const session = await client.session((keyspace = "phone_calls")); // 2
+	const session = await client.session((keyspace = keyspaceName)); // 2
 	const transaction = await session.transaction().read(); // 3
 
 	if (qsNumber == 0) {

--- a/phone_calls/nodejs/test.js
+++ b/phone_calls/nodejs/test.js
@@ -46,6 +46,8 @@ describe("Migration of data into Grakn", function() {
 
 describe("Queries on phone_calls_nodejs keyspace", function() {
     it("tests queries.js", async function() {
+        queries.processSelection(0);
+
         await csvMigration.init(dataPath, keyspaceName);
 
         transaction = await session.transaction().read()

--- a/phone_calls/nodejs/test.js
+++ b/phone_calls/nodejs/test.js
@@ -46,7 +46,7 @@ describe("Migration of data into Grakn", function() {
 
 describe("Queries on phone_calls_nodejs keyspace", function() {
     it("tests queries.js", async function() {
-        queries.processSelection(0);
+        queries.processSelection(0, keyspaceName);
 
         await csvMigration.init(dataPath, keyspaceName);
 

--- a/phone_calls/python/queries.py
+++ b/phone_calls/python/queries.py
@@ -264,6 +264,20 @@ aggregate_query_examples = [
 
 query_examples = get_query_examples + aggregate_query_examples
 
+def init(qs_number):
+    ## create a transaction to talk to the phone_calls keyspace
+    with GraknClient(uri="localhost:48555") as client:
+        with client.session(keyspace="phone_calls") as session:
+            with session.transaction().read() as transaction:
+                ## execute the query for the selected question
+                if qs_number == 0:
+                    execute_query_all(transaction)
+                else:
+                    question = query_examples[qs_number - 1]["question"]
+                    query_function = query_examples[qs_number - 1]["query_function"]
+                    query_function(question, transaction)
+
+
 if __name__ == "__main__":
 
     '''
@@ -287,14 +301,4 @@ if __name__ == "__main__":
         qs_number = int(input("choose a number (0 for to answer all questions): "))
     print("")
 
-    ## create a transaction to talk to the phone_calls keyspace
-    with GraknClient(uri="localhost:48555") as client:
-        with client.session(keyspace="phone_calls") as session:
-            with session.transaction().read() as transaction:
-                ## execute the query for the selected question
-                if qs_number == 0:
-                    execute_query_all(transaction)
-                else:
-                    question = query_examples[qs_number - 1]["question"]
-                    query_function = query_examples[qs_number - 1]["query_function"]
-                    query_function(question, transaction)
+    init(qs_number)

--- a/phone_calls/python/queries.py
+++ b/phone_calls/python/queries.py
@@ -230,9 +230,9 @@ def execute_query_7(question, transaction):
 
 def execute_query_all(transaction):
     for query_example in query_examples:
-        qustion = query_example["question"]
+        question = query_example["question"]
         query_function = query_example["query_function"]
-        query_function(qustion, transaction)
+        query_function(question, transaction)
         print("\n - - -  - - -  - - -  - - - \n")
 
 
@@ -264,10 +264,10 @@ aggregate_query_examples = [
 
 query_examples = get_query_examples + aggregate_query_examples
 
-def init(qs_number):
+def process_selection(qs_number, keyspace_name):
     ## create a transaction to talk to the phone_calls keyspace
     with GraknClient(uri="localhost:48555") as client:
-        with client.session(keyspace="phone_calls") as session:
+        with client.session(keyspace=keyspace_name) as session:
             with session.transaction().read() as transaction:
                 ## execute the query for the selected question
                 if qs_number == 0:
@@ -301,4 +301,4 @@ if __name__ == "__main__":
         qs_number = int(input("choose a number (0 for to answer all questions): "))
     print("")
 
-    init(qs_number)
+    process_selection(qs_number, "phone_calls")

--- a/phone_calls/python/test.py
+++ b/phone_calls/python/test.py
@@ -36,7 +36,7 @@ class Test(unittest.TestCase):
         self.assert_migration_results()
 
     def test_queries(self):
-        queries.init(0)
+        queries.process_selection(0, keyspace_name)
 
         migrate_csv.build_phone_call_graph(migrate_csv.Inputs, data_path, keyspace_name)
 

--- a/phone_calls/python/test.py
+++ b/phone_calls/python/test.py
@@ -36,6 +36,8 @@ class Test(unittest.TestCase):
         self.assert_migration_results()
 
     def test_queries(self):
+        queries.init(0)
+
         migrate_csv.build_phone_call_graph(migrate_csv.Inputs, data_path, keyspace_name)
 
         with self._session.transaction().read() as transaction:

--- a/tube_network/BUILD
+++ b/tube_network/BUILD
@@ -52,6 +52,7 @@ py_test(
         ":journey-planner",
         ":app"
     ],
+    timeout = "long",
     deps = [
         "@graknlabs_client_python//:client_python",
     ],

--- a/tube_network/src/app.py
+++ b/tube_network/src/app.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tkinter as tk
+import Tkinter as tk
 from grakn.client import GraknClient
 import datetime
 
@@ -110,6 +110,7 @@ class TubeGui:
     COMPUTE_CENTRALITY_TUNNEL_DEGREE = "compute centrality of station, in [station, tunnel], using degree;"
     COMPUTE_CENTRALITY_TUNNEL_KCORE = "compute centrality of station, in [station, tunnel], using k-core;"
     COMPUTE_CENTRALITY_ROUTE_DEGREE = "compute centrality of station, in [station, route], using degree;"
+    ANALYTICAL_QUERIES = [COMPUTE_CENTRALITY_TUNNEL_DEGREE, COMPUTE_CENTRALITY_TUNNEL_KCORE, COMPUTE_CENTRALITY_ROUTE_DEGREE]
 
     def __init__(self, session, root=tk.Tk()):
         """
@@ -603,9 +604,14 @@ class TubeGui:
             self._displaying_centrality = False
 
 
-if __name__ == "__main__":
+def init(shouldHalt):
     root = tk.Tk() # Build the Tkinter application
     with GraknClient(uri="localhost:48555") as client:
         with client.session(keyspace="tube_network") as session:
             tube_gui = TubeGui(session, root)
-            root.mainloop()
+            if shouldHalt:
+                root.mainloop()
+
+
+if __name__ == "__main__":
+    init(True)

--- a/tube_network/src/statistics.py
+++ b/tube_network/src/statistics.py
@@ -219,6 +219,19 @@ query_examples = [
     }
 ]
 
+def init(qs_number):
+    # create a transaction to talk to the keyspace
+    with GraknClient(uri="localhost:48555") as client:
+        with client.session(keyspace="tube_network") as session:
+            with session.transaction().read() as transaction:
+                # execute the query for the selected question
+                if qs_number == 0:
+                    execute_query_all(transaction)
+                else:
+                    question = query_examples[qs_number - 1]["question"]
+                    query_function = query_examples[qs_number - 1]["query_function"]
+                    query_function(question, transaction)
+
 if __name__ == "__main__":
 
     """
@@ -242,14 +255,4 @@ if __name__ == "__main__":
         qs_number = int(input("choose a number (0 for to answer all questions): "))
     print("")
 
-    # create a transaction to talk to the keyspace
-    with GraknClient(uri="localhost:48555") as client:
-        with client.session(keyspace="tube_network") as session:
-            with session.transaction().read() as transaction:
-                # execute the query for the selected question
-                if qs_number == 0:
-                    execute_query_all(transaction)
-                else:
-                    question = query_examples[qs_number - 1]["question"]
-                    query_function = query_examples[qs_number - 1]["query_function"]
-                    query_function(question, transaction)
+    init(qs_number)

--- a/tube_network/test.py
+++ b/tube_network/test.py
@@ -1,7 +1,7 @@
 from grakn.client import GraknClient
 import unittest
 
-from tube_network.src import migration, statistics, journey_planner
+from tube_network.src import migration, statistics, journey_planner, app
 
 
 class Test(unittest.TestCase):
@@ -20,6 +20,8 @@ class Test(unittest.TestCase):
         print("Loaded the tube_network data")
 
     def test_statistics(self):
+        statistics.init(0)
+
         query_examples = statistics.query_examples
 
         with GraknClient(uri="localhost:48555") as client:
@@ -62,6 +64,8 @@ class Test(unittest.TestCase):
                     )
 
     def test_journey_planner(self):
+        journey_planner.init(from_station_name="Green Park", to_station_name="Holloway Road", selected_path_strategy=1)
+
         with GraknClient(uri="localhost:48555") as client:
             with client.session(keyspace="tube_network") as session:
                 # not containing 'Underground Station'
@@ -91,12 +95,14 @@ class Test(unittest.TestCase):
                     [u'Green Park Underground Station', u'Holloway Road Underground Station']
                 )
 
-    # TODO: reinclude this test,
-    #       once `import _tkinter # If this fails your Python may not be configured for Tk` is resolved
-    # def test_visualisation_queries(self):
-    #     with GraknClient(uri="localhost:48555") as client:
-    #         with client.session(keyspace="tube_network") as session:
-    #             app.TubeGui(session)
+    def test_visualisation_queries(self):
+        app.init(False)
+
+        with GraknClient(uri="localhost:48555") as client:
+            with client.session(keyspace="tube_network") as session:
+                for query in app.TubeGui.ANALYTICAL_QUERIES:
+                    with session.transaction().read() as read_transaction:
+                        read_transaction.query(query)
 
     @classmethod
     def tearDownClass(cls):

--- a/tube_network/test.py
+++ b/tube_network/test.py
@@ -1,7 +1,7 @@
 from grakn.client import GraknClient
 import unittest
 
-from tube_network.src import migration, statistics, journey_planner, app
+from tube_network.src import migration, statistics, journey_planner
 
 
 class Test(unittest.TestCase):

--- a/tube_network/test.py
+++ b/tube_network/test.py
@@ -96,13 +96,13 @@ class Test(unittest.TestCase):
                 )
 
     def test_visualisation_queries(self):
-        app.init(False)
+        # app.init(False)
 
-        with GraknClient(uri="localhost:48555") as client:
-            with client.session(keyspace="tube_network") as session:
-                for query in app.TubeGui.ANALYTICAL_QUERIES:
-                    with session.transaction().read() as read_transaction:
-                        read_transaction.query(query)
+        # with GraknClient(uri="localhost:48555") as client:
+        #     with client.session(keyspace="tube_network") as session:
+        #         for query in app.TubeGui.ANALYTICAL_QUERIES:
+        #             with session.transaction().read() as read_transaction:
+        #                 read_transaction.query(query)
 
     @classmethod
     def tearDownClass(cls):

--- a/tube_network/test.py
+++ b/tube_network/test.py
@@ -95,7 +95,7 @@ class Test(unittest.TestCase):
                     [u'Green Park Underground Station', u'Holloway Road Underground Station']
                 )
 
-    def test_visualisation_queries(self):
+    # def test_visualisation_queries(self):
         # app.init(False)
 
         # with GraknClient(uri="localhost:48555") as client:


### PR DESCRIPTION
## What is the goal of this PR?
Test coverage of the `phone_calls` and `tube_network`  is increased to cover instantiation of `GraknClient`, `Session` and `Transaction`.

## What are the changes implemented in this PR?
- resolves #60 
- resolves #67 
- although the test coverage for `tube_network/app.py` has also been increased, its test method remains commented out until the #66 and #51 are resolved by @jmsfltchr.
- In `queries.py`, `queries.js` and `Queries.java` processing the user's selection is handled by a dedicated function/method which is exposed to and called from the corresponding test file.
- In `tube_network`:
    -  in `statistics.py` and `app.py`, an `init()` function is added to be exposed to and called from the corresponding test file.
    -  in `journey_planner`, the `find_path` function accepts certain arguments that are provided within the corresponding test method in order to bypass the need for `input` from the user.
    - given the compute queries that run within `tube_network/test.py`, the `timeout` attribute of the corresponding `py_test`, is sent to `long` to ensure tests complete before a timeout. 