### PR TITLE
Make tube_network compatible with both Python 2 and Python 3

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,14 +22,14 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "27a4596b4338189e9529cff3d015f173e6eb4c5b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "3af1176cf82b9ec89344ede92321d9c670a36f49", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "b26a2c0abbd79bcb1c95dba560ad2cf16e1b6609" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "eaad73ec1ad3acf91a6d2f085d55297f8c738f7f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():

--- a/tube_network/src/app.py
+++ b/tube_network/src/app.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tkinter as tk
+from six.moves import tkinter as tk
 from grakn.client import GraknClient
 import datetime
 


### PR DESCRIPTION
## What is the goal of this PR?

As we are having trouble running `tube_network` tests on Python 3 locally (mainly due to the fact that `pip` points to Python 2), they are now made cross-compatible with Python 2.

## What are the changes implemented in this PR?

- upgrade `@graknlabs_build_tools` to latest `master`
- upgrade `@graknlabs_grakn_core` to latest `master`
- import cross-compatible Tk library