### PR TITLE
Fix CI by bumping @graknlabs_build_tools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-grakn-server
+      - run: sleep 60
       - run: bazel test //phone_calls/nodejs:test --test_output=errors
 
   test-phone-calls-python:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "54109ff7428d0b7c04bd30ecff6f7e77f32c1bfd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "499a203981325e3ee50e3fc2f5298bad8a6bf683", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

Fix failing CI

## What are the changes implemented in this PR?

Bump `@graknlabs_build_tools` such that changes in graknlabs/bazel-distribution#196 are included
