### PR TITLE
Remove dependency on @graknlabs_grakn_core//concept

### DIFF
--- a/phone_calls/java/BUILD
+++ b/phone_calls/java/BUILD
@@ -46,7 +46,6 @@ java_library(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept"
     ]
 )
 
@@ -133,7 +132,6 @@ java_binary(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept"
     ],
     classpath_resources = [
         "@graknlabs_grakn_core//test-integration/resources:logback-test",


### PR DESCRIPTION
## What is the goal of this PR?

Concept API library was removed from Grakn Core so `examples` need to be adapted

## What are the changes implemented in this PR?

Remove `@graknlabs_grakn_core//concept` from `deps` of all Java libraries
