### PR TITLE
Remove usage of .collect_concepts from Python code

### DIFF
--- a/phone_calls/python/queries.py
+++ b/phone_calls/python/queries.py
@@ -66,7 +66,7 @@ def execute_query_1(question, transaction):
     query = "".join(query)
 
     iterator = transaction.query(query)
-    answers = iterator.collect_concepts()
+    answers = [ans.get("phone-number") for ans in iterator]
     result = [answer.value() for answer in answers]
 
     print_to_log("Result:", result)
@@ -98,7 +98,7 @@ def execute_query_2(question, transaction):
     query = "".join(query)
 
     iterator = transaction.query(query)
-    answers = iterator.collect_concepts()
+    answers = [ans.get("phone-number") for ans in iterator]
     result = [answer.value() for answer in answers]
 
     print_to_log("Result:", result)
@@ -126,7 +126,7 @@ def execute_query_3(question, transaction):
     query = "".join(query)
 
     iterator = transaction.query(query)
-    answers = iterator.collect_concepts()
+    answers = [ans.get("phone-number") for ans in iterator]
     result = [answer.value() for answer in answers]
 
     print_to_log("Result:", result)
@@ -157,7 +157,9 @@ def execute_query_4(question, transaction):
     query = "".join(query)
 
     iterator = transaction.query(query)
-    answers = iterator.collect_concepts()
+    answers = []
+    for answer in iterator:
+        answers.extend(answer.map().values())
     result = [answer.value() for answer in answers]
 
     print_to_log("Result:", result)

--- a/tube_network/src/statistics.py
+++ b/tube_network/src/statistics.py
@@ -74,7 +74,7 @@ def query_northernmost_station(question, transaction):
     print_to_log("Query:", "\n".join(query))
     query = "".join(query)
 
-    answers = transaction.query(query).collect_concepts()
+    answers = [ans.get("nam") for ans in transaction.query(query)]
     result = [answer.value() for answer in answers]
 
     print_to_log("Northmost stations with " + str(lat) + " are: ", result)


### PR DESCRIPTION
**MERGE UPON NEXT RELEASE OF CLIENT PYTHON**

## What is the goal of this PR?

Currently Python examples in documentation are wrong because they use `.collect_concepts` method no longer present in Grakn Client Python (see graknlabs/client-python#77)

## What are the changes implemented in this PR?

Replace usage of `.collect_concepts` with list comprehensions