### PR TITLE
Depend on artifact for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ commands:
   run-grakn:
     steps:
       - run-bazel:
-          command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
-      - run: mkdir dist && tar -xvzf bazel-bin/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
+          command: bazel run //:grakn-extractor -- dist/grakn-core-all-linux
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 
 jobs:

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_extractor")
+
+artifact_extractor(
+    name = "grakn-extractor",
+    artifact = "@graknlabs_grakn_core_artifact//file",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,7 +144,7 @@ graknlabs_bazel_distribution_pip_install()
 ###############################
 # Load @graknlabs_client_java #
 ###############################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
 
@@ -177,7 +177,7 @@ graknlabs_grabl_tracing()
 #################################
 # Load @graknlabs_client_python #
 #################################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_python")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_python")
 graknlabs_client_python()
 pip3_import(
     name = "graknlabs_client_python_pip",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,10 +148,10 @@ load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
 
-#######################################################
-# Load @graknlabs_common (from @graknlabs_client_java) #
-#######################################################
-load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_common")
+##########################
+# Load @graknlabs_common #
+##########################
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_common")
 graknlabs_common()
 
 #######################################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,7 @@ workspace(name = "graknlabs_examples")
 ################################
 # Load @graknlabs_dependencies #
 ################################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_dependencies")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_dependencies")
 graknlabs_dependencies()
 
 # Load Antlr
@@ -141,52 +141,38 @@ pip_import(
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
 graknlabs_bazel_distribution_pip_install()
 
-##############################
-# Load @graknlabs_grakn_core #
-##############################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core")
-graknlabs_grakn_core()
-load("@graknlabs_grakn_core//dependencies/maven:artifacts.bzl", graknlabs_grakn_core_artifacts = "artifacts")
-
-#######################################################
-# Load @graknlabs_common (from @graknlabs_grakn_core) #
-#######################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_common")
-graknlabs_common()
-
-######################################################
-# Load @graknlabs_graql (from @graknlabs_grakn_core) #
-######################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql")
-graknlabs_graql()
-load("@graknlabs_graql//dependencies/maven:artifacts.bzl", graknlabs_graql_artifacts = "artifacts")
-
-#########################################################
-# Load @graknlabs_protocol (from @graknlabs_grakn_core) #
-#########################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_protocol")
-graknlabs_protocol()
-load("@graknlabs_protocol//dependencies/maven:artifacts.bzl", graknlabs_protocol_artifacts = "artifacts")
-
-##############################################################
-# Load @graknlabs_grabl_tracing (from @graknlabs_grakn_core) #
-##############################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_grabl_tracing")
-graknlabs_grabl_tracing()
-
-########################################################
-# Load @graknlabs_console (from @graknlabs_grakn_core) #
-########################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_console")
-graknlabs_console()
-load("@graknlabs_console//dependencies/maven:artifacts.bzl", graknlabs_console_artifacts = "artifacts")
-
 ###############################
 # Load @graknlabs_client_java #
 ###############################
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
+
+#######################################################
+# Load @graknlabs_common (from @graknlabs_client_java) #
+#######################################################
+load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_common")
+graknlabs_common()
+
+#######################################################
+# Load @graknlabs_graql (from @graknlabs_client_java) #
+#######################################################
+load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql")
+graknlabs_graql()
+load("@graknlabs_graql//dependencies/maven:artifacts.bzl", graknlabs_graql_artifacts = "artifacts")
+
+##########################################################
+# Load @graknlabs_protocol (from @graknlabs_client_java) #
+##########################################################
+load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_protocol")
+graknlabs_protocol()
+load("@graknlabs_protocol//dependencies/maven:artifacts.bzl", graknlabs_protocol_artifacts = "artifacts")
+
+###############################################################
+# Load @graknlabs_grabl_tracing (from @graknlabs_client_java) #
+###############################################################
+load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_grabl_tracing")
+graknlabs_grabl_tracing()
 
 #################################
 # Load @graknlabs_client_python #
@@ -200,6 +186,12 @@ pip3_import(
 load("@graknlabs_client_python_pip//:requirements.bzl",
 graknlabs_client_python_pip_install = "pip_install")
 graknlabs_client_python_pip_install()
+
+#######################################
+# Load @graknlabs_grakn_core_artifact #
+#######################################
+load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
+graknlabs_grakn_core_artifact()
 
 ############################
 # Load @graknlabs_examples #
@@ -231,10 +223,8 @@ phone_calls_pip_install()
 # Load @maven #
 ###############
 maven(
-    graknlabs_grakn_core_artifacts +
     graknlabs_graql_artifacts +
     graknlabs_protocol_artifacts +
-    graknlabs_console_artifacts +
     graknlabs_client_java_artifacts +
     graknlabs_examples_artifacts
 )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_file")
+
+def graknlabs_grakn_core_artifact():
+    artifact_file(
+        name = "graknlabs_grakn_core_artifact",
+        group_name = "graknlabs_grakn_core",
+        artifact_name = "grakn-core-all-linux-{version}.tar.gz",
+        commit = "7cc0fcc8e44eb419f540b5ccedb4fcfe23c26e32",
+    )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -44,3 +44,10 @@ def graknlabs_client_nodejs():
         remote = "https://github.com/graknlabs/client-nodejs",
         commit = "f524486e27a4e489c8e35f27df601b15ccafc423" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
     )
+
+def graknlabs_common():
+    git_repository(
+        name = "graknlabs_common",
+        remote = "https://github.com/graknlabs/common",
+        commit = "7a3acbe71472f1dcbc9a04d7430ff60e39b74b92", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
+    )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,14 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "df4ebc603e1ef7fedc5bac9bc81b77905d4fe067", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
-    )
-
-def graknlabs_grakn_core():
-    git_repository(
-        name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "b300d443da017e83835efa3faa6c5853bdd68a4b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "504561c1343b12cfb08cd65c25155045da0b709e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_client_java():

--- a/phone_calls/java/BUILD
+++ b/phone_calls/java/BUILD
@@ -64,7 +64,7 @@ java_test(
         ":queries-lib"
     ],
     classpath_resources = [
-        "@graknlabs_grakn_core//test/resources:logback-test",
+        "@graknlabs_common//test//server:logback.xml",
     ],
     data = [
         "//schemas:phone-calls-schema.gql"
@@ -82,7 +82,7 @@ java_binary(
         "@maven//:com_univocity_univocity_parsers"
     ],
     classpath_resources = [
-        "@graknlabs_grakn_core//test/resources:logback-test",
+        "@graknlabs_common//test//server:logback.xml",
     ],
     data = [
         "//datasets:phone-calls-data-csv"
@@ -100,7 +100,7 @@ java_binary(
         "@maven//:com_google_code_gson_gson",
     ],
     classpath_resources = [
-        "@graknlabs_grakn_core//test/resources:logback-test",
+        "@graknlabs_common//test//server:logback.xml",
     ],
     data = [
         "//datasets:phone-calls-data-json"
@@ -118,7 +118,7 @@ java_binary(
         "@maven//:javax_xml_stream_stax_api"
     ],
     classpath_resources = [
-        "@graknlabs_grakn_core//test/resources:logback-test",
+        "@graknlabs_common//test//server:logback.xml",
     ],
     data = [
         "//datasets:phone-calls-data-xml"
@@ -134,6 +134,6 @@ java_binary(
         "@graknlabs_graql//java:graql",
     ],
     classpath_resources = [
-        "@graknlabs_grakn_core//test/resources:logback-test",
+        "@graknlabs_common//test//server:logback.xml",
     ]
 )

--- a/phone_calls/java/BUILD
+++ b/phone_calls/java/BUILD
@@ -63,9 +63,6 @@ java_test(
         ":xml-migration-lib",
         ":queries-lib"
     ],
-    classpath_resources = [
-        "@graknlabs_common//test//server:logback.xml",
-    ],
     data = [
         "//schemas:phone-calls-schema.gql"
     ]
@@ -80,9 +77,6 @@ java_binary(
         "@graknlabs_graql//java:graql",
         "@maven//:org_sharegov_mjson",
         "@maven//:com_univocity_univocity_parsers"
-    ],
-    classpath_resources = [
-        "@graknlabs_common//test//server:logback.xml",
     ],
     data = [
         "//datasets:phone-calls-data-csv"
@@ -99,9 +93,6 @@ java_binary(
         "@maven//:org_sharegov_mjson",
         "@maven//:com_google_code_gson_gson",
     ],
-    classpath_resources = [
-        "@graknlabs_common//test//server:logback.xml",
-    ],
     data = [
         "//datasets:phone-calls-data-json"
     ]
@@ -117,9 +108,6 @@ java_binary(
         "@maven//:org_sharegov_mjson",
         "@maven//:javax_xml_stream_stax_api"
     ],
-    classpath_resources = [
-        "@graknlabs_common//test//server:logback.xml",
-    ],
     data = [
         "//datasets:phone-calls-data-xml"
     ]
@@ -133,7 +121,4 @@ java_binary(
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
     ],
-    classpath_resources = [
-        "@graknlabs_common//test//server:logback.xml",
-    ]
 )


### PR DESCRIPTION
## What is the goal of this PR?

We now depend on grakn core artifact for tests in order to avoid bringing in its source dependencies and rebuilding it with our own overridden dependencies. This is because we do not need grakn core to be included as source since it is only run for tests.

## What are the changes implemented in this PR?

- Removed grakn core
- Added grakn core artifact
