### PR TITLE
Fix path in GitHub App Downloader

### DIFF
--- a/software/github/state/Downloader.kt
+++ b/software/github/state/Downloader.kt
@@ -103,6 +103,6 @@ class Downloader {
 
     companion object {
         private const val COMMITS_TO_DOWNLOAD = 25
-        private const val DATASETS_PATH = "github/datasets"
+        private const val DATASETS_PATH = "software/github/datasets"
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

The GitHub app now has the correct path to existing datasets that come packaged with the app.

## What are the changes implemented in this PR?

We've added the software folder to the path pointing to the datasets.

This was missed in the domain-based restructure.
